### PR TITLE
Add labels mechanism and actor-affinity-feature proposal

### DIFF
--- a/reps/2022-08-31-actor-affinity-apis.md
+++ b/reps/2022-08-31-actor-affinity-apis.md
@@ -54,6 +54,9 @@ Advantage
 
 ### API Design
 
+The API here is temporarily expressed in this form.
+If the form of the API is determined in 2022-11-23-labels-mechanish-and-affinity-schedule-feature.md later, I will modify the API here.
+
 #### Python API
 Python API Design:  
 Set key-value labels for actors

--- a/reps/2022-08-31-actor-affinity-apis.md
+++ b/reps/2022-08-31-actor-affinity-apis.md
@@ -1,0 +1,430 @@
+
+## Summary
+### General Motivation
+
+Provides a set of lightweight actor affinity and anti-affinity scheduling interfaces.
+Replacing the heavy PG interface to implement collocate or spread actors.
+
+* Affinity
+  * Co-locate the actors in the same node.
+  * Co-locate the actors in the same batch of nodes, like nodes in the same zones
+* Anti-affinity
+  * Spread the actors of a service across nodes and/or availability zones, e.g. to reduce correlated failures.
+  * Give a actor "exclusive" access to a node to guarantee resource isolation 
+  * Spread the actors of different services that will affect each other on different nodes.
+
+
+### Should this change be within `ray` or outside?
+
+Yes, this will be a complement to ray core's ability to flexibly schedule actors/tasks.
+
+## Stewardship
+### Required Reviewers
+ 
+@wumuzi520 SenlinZhu @WangTaoTheTonic  @scv119 (Chen Shen) @jjyao (Jiajun Yao) 
+### Shepherd of the Proposal (should be a senior committer)
+
+
+## Design and Architecture
+
+### Brief idea
+
+1. Tag the Actor with key-value labels first
+2. Then affinity or anti-affinity scheduling to the actors of the specified labels.
+
+![ActorAffinityScheduling](https://user-images.githubusercontent.com/11072802/188054945-48d980ed-2973-46e7-bf46-d908ecf93b31.jpg)
+
+Actor affinity/anti-affinity schedule API Design
+1. Scheduling Strategy adds an ActorAffinitySchedulingStrategy. 
+2. This strategy consists of several ActorAffinityMatchExpressions.
+3. ActorAffinityMatchExpression has 4 match types which are IN/NOT_IN/EXISTS/DOES_NOT_EXIST
+
+Use Case | ActorAffinityOperator
+-- | --
+Affinity | IN/EXISTS
+Anti-Affinity | NOT_IN/DOES_NOT_EXIST
+
+This is to learn the Affinity & Anti-Affinity features of K8s.
+
+Advantage
+1. Adding the Label mechanism makes affinity scheduling and anti-affinity scheduling particularly flexible. Actor scheduling of various topology types can be fully realized.
+2. There can be many extensions to the actor's label mechanism, such as obtaining the actor based on the label.  
+
+
+
+### API Design
+
+#### Python API
+Python API Design:  
+Set key-value labels for actors
+```python
+class ActorClass:
+    def options(self,
+                .....
+                labels: Dist[str, str] = None)
+```
+
+Actor affinity scheduling strategy API
+```python
+SchedulingStrategyT = Union[None, str,
+                            PlacementGroupSchedulingStrategy,
+                            NodeAffinitySchedulingStrategy,
+                            ActorAffinitySchedulingStrategy]
+
+class ActorAffinitySchedulingStrategy:
+    def __init__(self, match_expressions: List[ActorAffinityMatchExpression]):
+        self.match_expressions = match_expressions
+
+class ActorAffinityMatchExpression:
+    """An expression used to represent an actor's affinity.
+    Attributes:
+        key: the key of label
+        operator: IN、NOT_IN、EXISTS、DOES_NOT_EXIST,
+                  if EXISTS、DOES_NOT_EXIST, values set []
+        values: a list of label value
+        soft: ...
+    """
+    def __init__(self, key: str, operator: ActorAffinityOperator,
+                 values: List[str], soft: bool):
+        self.key = key
+        self.operator = operator
+        self.values = values
+        self.soft = soft
+
+```
+
+Python API example:  
+Step 1: Set the labels for this actor.   
+Each label consists of a key and value of type string.
+```python
+actor_1 = Actor.options(labels={
+    "location": "dc_1"
+}).remote()
+```
+
+Step 2: Set actor affinity strategy.  
+1. The target actor is expected to be scheduled with the actors whose label key is "location" and value in ["dc-1"].
+```python
+match_expressions = [
+    ActorAffinityMatchExpression("location", ActorAffinityOperator.IN, ["dc_1"], False)
+]
+actor_affinity_strategy = ActorAffinitySchedulingStrategy(match_expressions)
+actor = Actor.options(scheduling_strategy = actor_affinity_strategy).remote()
+```
+
+2. The target actor is not expected to be scheduled
+with the actors whose label key is "location" and value in ["dc-1"].
+```python
+match_expressions = [
+ ActorAffinityMatchExpression("location", ActorAffinityOperator.NOT_IN, ["dc_1"], False)
+]
+actor_affinity_strategy = ActorAffinitySchedulingStrategy(match_expressions)
+actor = Actor.options(scheduling_strategy = actor_affinity_strategy).remote()
+```
+
+3. The target actor is expected to be scheduled with the actors whose label key exists "location".
+```python
+match_expressions = [
+ ActorAffinityMatchExpression("location", ActorAffinityOperator.EXISTS, [], False)
+]
+actor_affinity_strategy = ActorAffinitySchedulingStrategy(match_expressions)
+actor = Actor.options(scheduling_strategy = actor_affinity_strategy).remote()
+```
+
+4. The target actor is not expected to be scheduled with the actors whose label key exists "location".
+```python
+match_expressions = [
+ ActorAffinityMatchExpression("location", ActorAffinityOperator.DOES_NOT_EXIST, [], False)
+]
+actor_affinity_strategy = ActorAffinitySchedulingStrategy(match_expressions)
+actor = Actor.options(scheduling_strategy = actor_affinity_strategy).remote()
+```
+
+5. You can also set multiple expressions at the same time, and multiple expressions need to be satisfied when scheduling.
+```python
+match_expressions = [
+ ActorAffinityMatchExpression("location", ActorAffinityOperator.DOES_NOT_EXIST, [], False),
+ ActorAffinityMatchExpression("version", ActorAffinityOperator.EXISTS, [], False)
+]
+actor_affinity_strategy = ActorAffinitySchedulingStrategy(match_expressions)
+actor = Actor.options(scheduling_strategy = actor_affinity_strategy).remote()
+```
+
+### Java API
+
+Set the labels for this actor API
+```java
+  /**
+   * Set a key-value label.
+   *
+   * @param key the key of label.
+   * @param value the value of label.
+   * @return self
+   */
+  public T setLabel(String key, String value) {
+    builder.setLabel(key, value);
+    return self();
+  }
+
+  /**
+   * Set batch key-value labels.
+   *
+   * @param labels A map that collects multiple labels.
+   * @return self
+   */
+  public T setLabels(Map<String, String> labels) {
+    builder.setLabels(labels);
+    return self();
+  }
+```
+
+Actor affinity scheduling strategy API
+```java
+public class ActorAffinitySchedulingStrategy implements SchedulingStrategy {
+  private ActorAffinitySchedulingStrategy(List<ActorAffinityMatchExpression> expressions) {
+}
+
+public class ActorAffinityMatchExpression {
+  private String key;
+  private ActorAffinityOperator operator;
+  private List<String> values;
+  private boolean isSoft;
+
+  /**
+   * Returns an affinity expression to indicate that the target actor is expected to be scheduled
+   * with the actors whose label meets one of the composed key and values. eg:
+   * ActorAffinityMatchExpression.in("location", new ArrayList<>() {{ add("dc-1");}}, false).
+   *
+   * @param key The key of label.
+   * @param values A list of label values.
+   * @param isSoft If true, the actor will be scheduled even there's no matched actor.
+   * @return ActorAffinityMatchExpression.
+   */
+  public static ActorAffinityMatchExpression in(String key, List<String> values, boolean isSoft) {
+    return new ActorAffinityMatchExpression(key, ActorAffinityOperator.IN, values, isSoft);
+  }
+
+  /**
+   * Returns an affinity expression to indicate that the target actor is not expected to be
+   * scheduled with the actors whose label meets one of the composed key and values. eg:
+   * ActorAffinityMatchExpression.notIn( "location", new ArrayList<>() {{ add("dc-1");}}, false).
+   *
+   * @param key The key of label.
+   * @param values A list of label values.
+   * @param isSoft If true, the actor will be scheduled even there's no matched actor.
+   * @return ActorAffinityMatchExpression.
+   */
+  public static ActorAffinityMatchExpression notIn(
+      String key, List<String> values, boolean isSoft) {
+    return new ActorAffinityMatchExpression(key, ActorAffinityOperator.NOT_IN, values, isSoft);
+  }
+
+  /**
+   * Returns an affinity expression to indicate that the target actor is expected to be scheduled
+   * with the actors whose labels exists the specified key. eg:
+   * ActorAffinityMatchExpression.exists("location", false).
+   *
+   * @param key The key of label.
+   * @param isSoft If true, the actor will be scheduled even there's no matched actor.
+   * @return ActorAffinityMatchExpression.
+   */
+  public static ActorAffinityMatchExpression exists(String key, boolean isSoft) {
+    return new ActorAffinityMatchExpression(
+        key, ActorAffinityOperator.EXISTS, new ArrayList<String>(), isSoft);
+  }
+
+  /**
+   * Returns an affinity expression to indicate that the target actor is not expected to be
+   * scheduled with the actors whose labels exists the specified key. eg:
+   * ActorAffinityMatchExpression.doesNotExist("location", false).
+   *
+   * @param key The key of label.
+   * @param isSoft If true, the actor will be scheduled even there's no matched actor.
+   * @return ActorAffinityMatchExpression.
+   */
+  public static ActorAffinityMatchExpression doesNotExist(String key, boolean isSoft) {
+    return new ActorAffinityMatchExpression(
+        key, ActorAffinityOperator.DOES_NOT_EXIST, new ArrayList<String>(), isSoft);
+  }
+
+}
+
+```
+
+JAVA API example:  
+Step 1: Set labels for actors
+```java
+// Set a key-value label.
+// This interface can be called multiple times. The value of the same key will be overwritten by the latest one.
+ActorHandle<Counter> actor =
+    Ray.actor(Counter::new, 1)
+        .setLabel("location", "dc_1")
+        .remote();
+
+// Set batch key-value labels.
+Map<String, String> labels =
+    new HashMap<String, String>() {
+        {
+        put("location", "dc-1");
+        put("version", "1.0.0");
+        }
+    };
+ActorHandle<Counter> actor =
+    Ray.actor(Counter::new, 1)
+        .setLabels(labels)
+        .remote();
+```
+Step 2: Set actor affinity/anti-affinity strategy  
+1. Scheduling into node of actor which the value of label key "location" is in {"dc-1", "dc-2"}
+```java
+List<String> locationValues = new ArrayList<>();
+locationValues.add("dc_1");
+locationValues.add("dc_2");
+ActorAffinitySchedulingStrategy schedulingStrategy =
+    new ActorAffinitySchedulingStrategy.Builder()
+        .addExpression(ActorAffinityMatchExpression.in("location", locationValues, false))
+        .build();
+ActorHandle<Counter> actor2 =
+    Ray.actor(Counter::new, 1).setSchedulingStrategy(schedulingStrategy).remote();
+```
+
+2. Don't scheduling into node of actor which the value of label key "location" is in {"dc-1"}
+```java
+List<String> values = new ArrayList<>();
+values.add("dc-1");
+ActorAffinitySchedulingStrategy schedulingStrategyNotIn =
+    new ActorAffinitySchedulingStrategy.Builder()
+        .addExpression(ActorAffinityMatchExpression.notIn("location", values, false))
+        .build();
+ActorHandle<Counter> actor3 =
+    Ray.actor(Counter::new, 1).setSchedulingStrategy(schedulingStrategyNotIn).remote();
+```
+
+3. Scheduling into node of actor which exists the label key "version"
+```java
+ActorAffinitySchedulingStrategy schedulingStrategyExists =
+    new ActorAffinitySchedulingStrategy.Builder()
+        .addExpression(ActorAffinityMatchExpression.exists("version", false))
+        .build();
+ActorHandle<Counter> actor4 =
+    Ray.actor(Counter::new, 1).setSchedulingStrategy(schedulingStrategyExists).remote();
+Assert.assertEquals(actor4.task(Counter::getValue).remote().get(10000), Integer.valueOf(1));
+```
+
+4. Don't scheduling into node of actor which exist the label key "version"
+```java
+ActorAffinitySchedulingStrategy schedulingStrategyDoesNotExist =
+    new ActorAffinitySchedulingStrategy.Builder()
+        .addExpression(ActorAffinityMatchExpression.doesNotExist("version", false))
+        .build();
+ActorHandle<Counter> actor5 =
+    Ray.actor(Counter::new, 1).setSchedulingStrategy(schedulingStrategyDoesNotExist).remote();
+```
+
+5. You can also set multiple expressions at the same time, and multiple expressions need to be satisfied when scheduling.
+```java
+ActorAffinitySchedulingStrategy schedulingStrategy =
+    new ActorAffinitySchedulingStrategy.Builder()
+        .addExpression(ActorAffinityMatchExpression.doesNotExist("version", false))
+        .addExpression(ActorAffinityMatchExpression.Exists("location", false))
+        .build();
+ActorHandle<Counter> actor6 =
+    Ray.actor(Counter::new, 1).setSchedulingStrategy(schedulingStrategy).remote();
+```
+
+### Implementation plan
+Now there are two modes of scheduling: GCS mode scheduling and raylet scheduling.  
+It will be simpler to implement in GCS mode.
+#### GCS Scheduling Mode Implementation plan
+
+1. Actor adds the Labels property. Stored in the GcsActor structure
+2. Gcs Server add GcsLabelManager. Add labels->node information to GcsLabelManager after per actor completes scheduling.
+3. Added ActorAffinityPolicy, whose scheduling logic is to select the main scheduling node based on each matching expression and the labels->node information of GcsLabelManager
+
+The pseudo-code logic of the 4 matching operations is as follows:  
+Affinity Operator: IN
+```
+feasible_nodes = FindFeasibleNodes()
+for (expression : match_expressions) {
+    feasible_nodes = feasible_nodes ∩ GcsLabelManager->GetNodesByKeyAndValue(expression.key, expression.values)
+}
+```
+
+Affinity Operator: EXISTS
+```
+feasible_nodes = FindFeasibleNodes()
+for (expression : match_expressions) {
+    feasible_nodes = feasible_nodes ∩ GcsLabelManager->GetNodesByKey(expression.key)
+}
+```
+
+Affinity Operator: NOT_IN
+```
+feasible_nodes = FindFeasibleNodes()
+for (expression : match_expressions) {
+    feasible_nodes = feasible_nodes - GcsLabelManager->GetNodesByKeyAndValue(expression.key, expression. values)
+}
+```
+
+Affinity Operator: DOES_NOT_EXIST
+```
+feasible_nodes = FindFeasibleNodes()
+for (expression : match_expressions) {
+    feasible_nodes = feasible_nodes - GcsLabelManager->GetNodesByKey(expression.key)
+}
+```
+
+GcsLabelManger Desion  
+
+Add 4 public interfaces for GcsLabelManger :
+```c++
+// Add Actor's labels and node index relationship information.
+void AddActorLabels(const std::shared_ptr<GcsActor> &actor);
+
+// Remove Actor's labels and node index relationship information.
+void RemoveActorLabels(const std::shared_ptr<GcsActor> &actor);
+
+// Get the node where the actors those keys and values matched. 
+absl::flat_hash_set<NodeID> GetNodesByKeyAndValue(const std::string &ray_namespace, const std::string &key, const absl::flat_hash_set<std::string> &values) const;
+
+// Get the node where the actors which exist this key.
+absl::flat_hash_set<NodeID> GetNodesByKey(const std::string &ray_namespace, 
+                                          const std::string &key) const;
+```
+
+Main data structure :
+```
+Map<label_key, Map<lable_value, Set<node_id>>> label_to_nodes_
+Map<node_id, Set<GcsActor>> node_to_actors_
+```
+#### Raylet Scheduling Mode Implementation plan
+The implementation of Raylet scheduling mode is same as GCS scheduling above.  
+Mainly, one more Labels information needs to be synchronized to all Raylet nodes
+
+### Failures and Special Scenarios
+#### 1、If the Match Expression Cannot be satisfied
+If the matching expression cannot be satisfied, The actor will be add to the pending actor queue. Util the matching expression all be statisfied。
+
+Example:
+If the next actor want to co-locate with the previous actor but the previous actor don't complete schedule. The next actor will be add to pending actor queue. It will be schedule complete After the previous actor complete schedule.
+
+#### 2、Failures Scenarios
+If actor B collocates with actor A and The actor A & B both complete schedule to Node 1.
+1、If actor A failed and restarted to Node 2, the actor B will not be affected, it still working in Node 1.  
+2、If actor A failed and restarted to Node 2, Then the actor B also failed, It will be scheduled to Node 2 and collocates with actor A.
+
+### how other system achieve the same goal?
+1、K8s
+This solution is to learn the PodAffinity/NodeAffinity features of K8s。
+https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+
+### what's the alternative to achieve the same goal?
+1、Ray 
+Now ray placement group can achieve the same goal. But PG is too heavy and complicated to be user friendly
+## Compatibility, Deprecation, and Migration Plan
+
+## Test Plan and Acceptance Criteria
+All APIs will be fully unit tested. All specifications in this documentation will be thoroughly tested at the unit-test level. The end-to-end flow will be tested within CI tests. Before the beta release, we will add large-scale testing to precisely understand scalability limitations and performance degradation in large clusters. 
+
+## (Optional) Follow-on Work
+

--- a/reps/2022-11-23-labels-mechanish-and-affinity-schedule-feature.md
+++ b/reps/2022-11-23-labels-mechanish-and-affinity-schedule-feature.md
@@ -54,6 +54,16 @@ ray start ... --labels={"location": "dc_1"}
 **Option 1: Simplify through syntactic sugar**  
 
 ```python
+
+actor_0 = Actor.remote()
+actor_1 = Actor.options(
+        scheduling_strategy=actor_affinity(affinity(actor_0, false))
+    ).remote()
+
+actor_2 = Actor.options(
+        scheduling_strategy=actor_affinity(anti_affinity(actor_0, false))
+    ).remote()
+
 actor_1 = Actor.options(
         scheduling_strategy=actor_affinity(label_in("location", ["dc_1"], false))
     ).remote()
@@ -90,6 +100,14 @@ def label_exists(key, is_soft):
     return LabelMatchExpression(...)
 
 def label_does_not_exist(key, is_soft):
+    ...
+    return LabelMatchExpression(...)
+
+def affinity(actor_handles, is_soft):
+    ...
+    return LabelMatchExpression(...)
+
+def anti_affinity(actor_handles, is_soft):
     ...
     return LabelMatchExpression(...)
 ```

--- a/reps/2022-11-23-labels-mechanish-and-affinity-schedule-feature.md
+++ b/reps/2022-11-23-labels-mechanish-and-affinity-schedule-feature.md
@@ -1,0 +1,279 @@
+## Summary
+### General Motivation
+
+Introduce the Labels mechanism. Give Labels to Actors/Tasks/Nodes/Objects. 
+Affinity features such as ActorAffinity/TaskAffinity/NodeAffinity can be realized through Labels.
+
+
+### Should this change be within `ray` or outside?
+
+Yes, this will be a complement to ray core's ability to flexibly schedule actors/tasks/node.
+
+## Stewardship
+### Required Reviewers
+ 
+@wumuzi520 SenlinZhu @Chong Li  @scv119 (Chen Shen) @jjyao (Jiajun Yao) @Yi Cheng
+### Shepherd of the Proposal (should be a senior committer)
+
+
+## Design and Architecture
+
+### Brief idea
+1. Introduce the concept of Label. Add the Labels attribute to Actor/Task/Node. Labels = Map<String, String>.
+2. After Actor/Task are scheduled to a certain node, the Labels of Actor/Task will be attached to the node resource(Named: LabelsResource). Node's Labels are naturally in the node resource.
+3. Actor/Task scheduling can choose Actor/Task/NodeAffinitySchedulingStratgy. 
+4. The actual principle of Actor/Task/NodeAffinitySchedulingStratgy is. According to the label matching expression in the strategy, traverse and search for LabelsResource of all nodes. Pick out nodes that meet the expression requirements.
+
+![LabelsAffinity](https://user-images.githubusercontent.com/11072802/203686866-385235b5-e08b-4aac-9c31-512621129bd4.png)
+
+### API Design
+The apis of actors/tasks/nodes add labels.
+```python
+# Actor add labels.
+actor_1 = Actor.options(labels={
+    "location": "dc_1"
+}).remote()
+
+# Task add labels.
+task_1 = Task.options(labels={
+    "location": "dc_1"
+}).remote()
+
+#  Node add static labels. 
+ray start ... --labels={"location": "dc_1"}
+# The api of the dynamic update node labels is similar to the current dynamic set_resource. It can be determined later.
+```
+
+The apis of the actor-affinity/task-affinity/node-affinity scheduling.
+```python
+SchedulingStrategyT = Union[None, str,
+                            PlacementGroupSchedulingStrategy,
+                            ActorAffinitySchedulingStrategy,
+                            TaskAffinitySchedulingStrategy,
+                            NodeAffinitySchedulingStrategy]
+
+class ActorAffinitySchedulingStrategy:
+    def __init__(self, match_expressions: List[LabelMatchExpression]):
+        self.match_expressions = match_expressions
+
+class TaskAffinitySchedulingStrategy:
+    def __init__(self, match_expressions: List[LabelMatchExpression]):
+        self.match_expressions = match_expressions
+
+class NodeAffinitySchedulingStrategy:
+    def __init__(self, match_expressions: List[LabelMatchExpression]):
+        self.match_expressions = match_expressions
+
+class LabelMatchExpression:
+    """An expression used to select instance by instance's labels
+    Attributes:
+        key: the key of label
+        operator: IN、NOT_IN、EXISTS、DOES_NOT_EXIST,
+                  if EXISTS、DOES_NOT_EXIST, values set []
+        values: a list of label value
+        soft: ...
+    """
+    def __init__(self, key: str, operator: LabelMatchOperator,
+                 values: List[str], soft: bool):
+        self.key = key
+        self.operator = operator
+        self.values = values
+        self.soft = soft
+
+# ActorAffinity use case
+actor_1 = Actor.options(scheduling_strategy=ActorAffinitySchedulingStrategy([
+                LabelMatchExpression(
+                    "location", LabelMatchOperator.IN, ["dc_1"], False)
+            ])).remote()
+```
+
+
+### Implementation plan
+
+![LabelsAffinity](https://user-images.githubusercontent.com/11072802/203686851-894536d0-86fa-4fab-a5fe-2e656ac198e5.png)
+
+1. Add the actor_labels data structure to the resource synchronization data structure(ResourcesData and NodeResources). 
+```
+message ResourcesData {
+  // Node id.
+  bytes node_id = 1;
+  // Resource capacity currently available on this node manager.
+  map<string, double> resources_available = 2;
+  // Indicates whether available resources is changed. Only used when light
+  // heartbeat enabled.
+  bool resources_available_changed = 3;
+
+  // Map<label_type, Map<namespace, Map<label_key, label_value>>> Actors/Tasks/Nodes labels information
+  repeat Map<string, Map<string, Map<string, string>>> labels = 15
+  // Whether the actors of this node is changed.
+  bool labels_changed = 16,
+}
+
+
+NodeResources {
+  ResourceRequest total;
+  ResourceRequest available;
+  /// Only used by light resource report.
+  ResourceRequest load;
+  /// Resources owned by normal tasks.
+  ResourceRequest normal_task_resources
+  /// Map<label_type, Map<namespace, Map<label_key, label_value>>> Actors/Tasks/Nodes labels information
+  absl::flat_hash_map<string, absl::flat_hash_map<string, absl::flat_hash_map<string, string>>> labels;
+}
+```
+
+2. Adapts where ResourcesData is constructed and used in the resource synchronization mechanism.  
+a. NodeManager::HandleRequestResourceReport  
+b. NodeManager::HandleUpdateResourceUsage 
+
+
+3. Add Labels of actors/tasks to NodeResources during Actors/tasks scheduling
+
+
+4. Scheduling optimization through Labels  
+Take ActorAffinity's scheduling optimization scheme as an example：  
+Now any node raylet has ActorLabels information for all nodes.  
+when ActorAffinity schedules, if it traverses the Labels of all Actors of each node, the algorithm complexity is very large, and the performance will be poor.   
+** Therefore, it is necessary to generate a full-cluster ActorLabels index table to improve scheduling performance. </b>
+
+```
+class GcsLabelManager {
+ public:
+  absl::flat_hash_set<NodeID> GetNodesByKeyAndValue(const std::string &ray_namespace,
+      const std::string &key, const absl::flat_hash_set<std::string> &values) const;
+
+  absl::flat_hash_set<NodeID> GetNodesByKey(const std::string &ray_namespace,
+                                            const std::string &key) const;
+
+  void AddActorLabels(const std::shared_ptr<GcsActor> &actor);
+
+  void RemoveActorLabels(const std::shared_ptr<GcsActor> &actor);
+
+ private:
+ <namespace, <label_key, <lable_value, [node_id]>>> labels_to_nodes_;
+ <node_id, <namespace, [actor]>>  nodes_to_actors_;
+}
+```
+
+Actor scheduling flowchart：
+![Actor scheduling flowchart](https://user-images.githubusercontent.com/11072802/202128385-f72609c5-308d-4210-84ff-bf3ba6df381c.png)
+
+Node Resources synchronization mechanism:
+![Node Resources synchronization mechanism](https://user-images.githubusercontent.com/11072802/203783157-fad67f25-b046-49ac-b201-b54942073823.png)
+
+### how other system achieve the same goal?
+1、K8s
+This solution is to learn the PodAffinity/NodeAffinity features of K8s。
+https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+
+Scheduling Policy | Label Owner | Operator
+-- | -- | --
+nodeAffinity | NODE | In, NotIn, Exists, DoesNotExist, Gt, Lt
+podAffinity | POD | In, NotIn, Exists, DoesNotExist
+podAntiAffinity | POD | In, NotIn, Exists, DoesNotExist
+
+
+### what's the alternative to achieve the same goal?
+**Option 2: Use LabelAffinitySchedulingStrategy instead of Actor/Task/NodeAffinitySchedulingStrategy**  
+Some people think that ActorAffinity/TaskAffinity is dispatched to the Node corresponding to the actor/Task with these labels.  
+Why not assign both ActorLabels and TaskLabels to Node?   
+Then the scheduling API only needs to use the LabelAffinitySchedulingStrategy set of APIs to instead of Actor/Task/NodeAffinitySchedulingStrategy.  
+
+API Design:
+```
+SchedulingStrategyT = Union[None, str,
+                            PlacementGroupSchedulingStrategy,
+                            LabelAffinitySchedulingStrategy]
+
+class LabelAffinitySchedulingStrategy:
+    def __init__(self, match_expressions: List[LabelMatchExpression]):
+        self.match_expressions = match_expressions
+
+class LabelMatchExpression:
+    """An expression used to select instance by instance's labels
+    Attributes:
+        key: the key of label
+        operator: IN、NOT_IN、EXISTS、DOES_NOT_EXIST,
+                  if EXISTS、DOES_NOT_EXIST, values set []
+        values: a list of label value
+        soft: ...
+    """
+    def __init__(self, key: str, operator: LabelMatchOperator,
+                 values: List[str], soft: bool):
+        self.key = key
+        self.operator = operator
+        self.values = values
+        self.soft = soft
+
+
+actor_1 = Actor.options(scheduling_strategy=LabelAffinitySchedulingStrategy([
+                LabelMatchExpression(
+                    "location", LabelMatchOperator.IN, ["dc_1"], False)
+            ])).remote()
+```
+
+**Why didn't you choose this option?**   
+1. Actor and Task are isolated by namespace. But Node has no namespace isolation. As a result, Actor/Task labels cannot be directly integrated with Node labels.
+2. Separately divided into Actor/Task/NodeAffinity. In this way, the interface semantics will be more simple and concise. Avoid conceptual confusion.
+3. LabelAffinity combines the labels of Actor/Task/Node at the same time. The final scheduling result may not be accurate. Users only want to use ActorAffinity. But other Tasks have the same labels with actor labels. This scene will make scheduling result not be accurate.
+
+Advantages:
+1. It is possible to realize the scene of affinity with Actor/Task/Node at the same time.  
+Example:  
+The user wants to affinity schedule to <b> some Actors and nodes in a special computer room. </b>   
+However, according to the results of internal user research, most of the requirements are just to realize Actor/Task "collocate" scheduling or spread scheduling.  
+So using a single ActorAffinity/TaskAffinity/NodeAffinity can already achieve practical effects.  
+
+And the same effect can be achieved by combining the option 1 with custom resources
+
+
+** Option 3: putting Labels into the custom resource solution  **  
+```
+class ResourceRequest {
+    absl::flat_hash_map<ResourceID, FixedPoint> resources_;
+}
+
+Add Actor/Task/Node labels to resources_ as custom resources.
+eg:  
+{
+    "CPU": 16,
+    "memory": xx,
+    "custom_resources": xx,
+    "actor_labels_key@value": 1,
+    "task_labels_key@value": 1,
+    "node_labels_key@value": 1,
+}
+```
+If you put labels into custom_resources, you need to do the following adaptation:
+1. Compared with custom_resources, labels need to add a specific prefix to distinguish them from custom_resources.
+2. The key and value of Labels need to be concatenated with special characters (@).
+3. When using Labels to build a Labels index table, you need to parse the resources key.
+
+**DisAdvantages:**
+1. Labels unlike cpu resource these are numeric types. Compared with the above scheme. This will destroy the concept of coustrom resouce.
+2. Actor and Task are isolated by namespace. It is difficult to isolate through namespace if adding custom_resource.
+2. The Label index table of all nodes can be constructed from the ActorLabels information of each node. If you use Custom Resource, this requires parsing the resource_key and doing a lot of string splitting which will cost performance.
+3. If custom_resource happens to be the same as the spliced string of labels. Then it will affect the correctness of scheduling.
+
+
+**Advantages:**
+1. The interface for resource reporting and updating don't modify.
+
+## Compatibility, Deprecation, and Migration Plan
+
+## Test Plan and Acceptance Criteria
+All APIs will be fully unit tested. All specifications in this documentation will be thoroughly tested at the unit-test level. The end-to-end flow will be tested within CI tests. Before the beta release, we will add large-scale testing to precisely understand scalability limitations and performance degradation in large clusters. 
+
+## (Optional) Follow-on Work
+
+### 1. Expression of "OR" semantics.
+Later, if necessary, you can extend the semantics of "OR" by adding "is_or_semantics" to ActorAffinitySchedulingStrategy.
+```
+class ActorAffinitySchedulingStrategy:
+    def __init__(self, match_expressions: List[LabelMatchExpression], is_or_semantics = false):
+        self.match_expressions = match_expressions
+        self.is_or_semantics = 
+```
+
+### 2. ObjectAffinitySchedulingStrategy
+If the user has a request, you can consider adding the attributes of labels to objects. Then the strategy of ObjectAffinity can be launched。


### PR DESCRIPTION
# 1. Labels mechanism.
Introduce the Labels mechanism. Give Labels to Actors/Nodes. 
Affinity features such as ActorAffinity/NodeAffinity can be realized through Labels.

Read reps/2022-11-23-labels-mechanish-and-affinity-schedule-feature.md first.

# 2.  Actor-Affinity Feature
Provides a set of lightweight actor affinity and anti-affinity scheduling interfaces.
Replacing the heavy PG interface to implement collocate or spread actors.

* Affinity
  * Co-locate the actors in the same node.
  * Co-locate the actors in the same batch of nodes, like nodes in the same zones
* Anti-affinity
  * Spread the actors of a service across nodes and/or availability zones, e.g. to reduce correlated failures.
  * Give a actor "exclusive" access to a node to guarantee resource isolation 
  * Spread the actors of different services that will affect each other on different nodes.

![ActorAffinity调度](https://user-images.githubusercontent.com/11072802/188054945-48d980ed-2973-46e7-bf46-d908ecf93b31.jpg)