### PR TITLE
[AIR/Data] Revamping APIs for Offline Batch Inference

### DIFF
--- a/reps/2023-03-10-batch-inference.md
+++ b/reps/2023-03-10-batch-inference.md
@@ -1,0 +1,149 @@
+# Revamping APIs for Offline Batch Inference
+
+## Summary
+Reduce the friction for batch inference of pre-trained by updating the APIs to do the following:
+1. Remove AIR Checkpoints from the critical path for batch prediction.
+2. Simpler interface for chaining multiple preprocessing and prediction stages.
+
+### General Motivation
+There are changes to Ray Datasets in 2.3/2.4:
+1. Ray Datasets became lazy by default in Ray 2.3. Execution is no longer triggered until consumption is explicitly called.
+2. In Ray 2.4, Ray Datasets will move to streaming execution by default, resulting in there no longer being a separation between `Dataset` and `DatasetPipeline`. 
+3. In Ray 2.4, Ray Datasets will support a `"zero_copy"` batch format, allowing the core Ray Data to decide the most optimal batch format to use.
+
+With these changes, certain API choices that were made for the AIR batch prediction API are no longer the most optimal for simplicity and usability.
+1. Previously, AIR would manually fuse preprocessing and prediction stages, requiring `BatchPredictor` to be aware of the preprocessors passed in via a `Checkpoint`. This is not needed anymore with Datasets lazy by default, as the fusion logic can be pushed down to the Datasets layer.
+2. Previously, the separation of `Dataset` and `DatasetPipeline` resulted in `BatchPredictor` needing 2 analgous APIs: `predict` and `predict_pipelined`. This is not needed anymore with streaming as default execution.
+3. Previously, the logic for determining batch format was decided in the AIR layer in `Preprocessor` and `BatchPredictor`. This is not needed anymore with zero-copy batch format, as this decision making can be pushed down to the Datasets layer.
+
+### Should this change be within `ray` or outside?
+main `ray` project. Changes are made to Ray Data and Ray AIR level.
+
+## Stewardship
+### Required Reviewers
+The proposal will be open to the public, but please suggest a few experience Ray contributors in this technical domain whose comments will help this proposal. Ideally, the list should include Ray committers.
+
+@ericl, @clarkzinzow, @c21, @gjoliver
+
+### Shepherd of the Proposal (should be a senior committer)
+To make the review process more productive, the owner of each proposal should identify a **shepherd** (should be a senior Ray committer). The shepherd is responsible for working with the owner and making sure the proposal is in good shape (with necessary information) before marking it as ready for broader review.
+
+@ericl
+
+## Design and Architecture
+
+## API Changes
+
+1. Introduce `map_preprocessor` API directly to Ray Datasets.
+
+```python
+def map_preprocessor(preprocessor: Preprocessor, batch_size: Optional[int], prefetch_batches: Optional[int]):
+  """Apply the transform of the provided preprocessor to batches of data.
+
+  Args:
+    preprocessor: A :class:`~ray.data.preprocessor.Preprocessor` used to transform batches of data. The provided preprocessor is
+      expected to already be fitted if it is fittable.
+    batch_size: Same as `map_batches`
+    prefetch_batches: Same as `map_batches`
+  """
+```
+
+2. Introduce a `map_predictor` API directly to Ray Datasets.
+
+```python
+def map_predictor(predictor: Union[Predictor, Callable[[], Predictor]], 
+                  batch_size: Optional[int], 
+                  feature_columns: Optional[List[str]] = None, 
+                  keep_columns: Optional[List[str]] = None, 
+                  prefetch_batches: Optional[int] = 0, 
+                  min_scoring_workers: int = 1,
+                  max_scoring_workers: Optional[int] = None,
+                  num_cpus_per_worker: Optional[int] = None,
+                  num_gpus_per_worker: Optional[int] = None, 
+                  **predict_kwargs):
+  """Predict on batches of data.
+
+  Args:
+    predictor: An instance of a Predictor to use for prediction. For Predictors that are not serializable, or are loading large models
+      or that are created from AIR Checkpoints, a function that creates a Predictor can be passed in instead. 
+    batch_size: Batch size to use for prediction.
+    feature_columns: List of columns in the preprocessed dataset to use for
+      prediction. Columns not specified will be dropped
+      from `data` before being passed to the predictor.
+      If None, use all columns in the preprocessed dataset.
+    keep_columns: List of columns in the preprocessed dataset to include
+        in the prediction result. This is useful for calculating final
+        accuracies/metrics on the result dataset. If None,
+        the columns in the output dataset will contain
+        just the prediction results.
+    min_scoring_workers: Minimum number of scoring actors.
+    max_scoring_workers: If set, specify the maximum number of scoring actors.
+    num_cpus_per_worker: Number of CPUs to allocate per scoring worker.
+      Set to 1 by default.
+    num_gpus_per_worker: Number of GPUs to allocate per scoring worker.
+      Set to 0 by default. If you want to use GPUs for inference, please
+      specify this parameter.
+    ray_remote_args: Additional resource requirements to request from ray.
+    predict_kwargs: Keyword arguments passed to the predictor's
+        ``predict()`` method.
+```
+
+3. Deprecate `Chain` Preprocessor, as chains can be represented via multiple `map_preprocessor` calls.
+4. Deprecate `BatchMapper`, as the same functionality can be achieved via `map_batches`.
+      
+## Example: Multi-stage Inference Pipeline from pre-trained model
+
+Note that Checkpoints are not on the critical path, but can still be used.
+
+### Before
+```python
+preprocessor1 = BatchMapper(lambda x: x+1)
+preprocessor2 = TorchVisionPreprocessor(torchvision.transforms.Crop(224, 224))
+chained = Chain([preprocessor1, preprocessor2])
+
+model = pretrained_resnet()
+checkpoint = TorchCheckpoint.from_model(model, preprocessor=chained)
+batch_predictor = BatchPredictor.from_checkpoint(checkpoint)
+
+ds = ds.read_parquet("s3://data")
+predictions = batch_predictor.predict(ds)
+```
+
+### After
+```python
+model = pretrained_resnet()
+predictor = TorchPredictor(model)
+
+# Alternatively, delayed model creation
+# predictor = lambda: TorchPredictor(pretrained_resnet())
+
+# Alternatively, create from AIR Checkpoint.
+# predictor = lambda: TorchPredictor.from_checkpoint(air_checkpoint)
+
+predictions = ds.read_parquet("s3://data")
+    .map_batches(lambda x: x+1)
+    .map_preprocessor(TorchVisionPreprocessor(torchvision.transforms.Crop(224, 224)))
+    .map_predict(predictor)
+```
+
+## Compatibility, Deprecation, and Migration Plan
+An important part of the proposal is to explicitly point out any compability implications of the proposed change. If there is any, we should thouroughly discuss a plan to deprecate existing APIs and migration to the new one(s).
+
+Ray 2.4: Onboard new users onto new APIs
+- Introduce `map_preprocessor` and `map_predictor` as Alpha APIs.
+- Rewrite all batch inference examples to use these APIs, and use `map_batches` directly instead of `BatchMapper` and `Chain`.
+- `BatchPredictor` will still be fully supported.
+
+Ray 2.5: Start migrating existing users to new APIs
+- Soft Deprecate `BatchPredictor`. Warn if this API is used, and remove from Documentation.
+- Add migration guide in documentation for guidance on how to migrate to the new APIs.
+
+Ray 2.6: Deprecate old APIs
+- Hard deprecate `BatchPredictor`.
+
+
+## Test Plan and Acceptance Criteria
+The proposal should discuss how the change will be tested **before** it can be merged or enabled. It should also include other acceptance criteria including documentation and examples. 
+
+- Unit and integration for new APIs
+- Documentation and examples on new API.

--- a/reps/2023-03-10-batch-inference.md
+++ b/reps/2023-03-10-batch-inference.md
@@ -384,9 +384,11 @@ def map_batches(
 
 ## FAQ
 1. If I pass in a `Predictor` directly, won't initiliazation happen for every batch?
+
 No. `Predictors` will require the use of a Callable Class, and so that we wrap the Predictor in a Callable class internally, like in the example above.
 
 2. If I have an AIR Checkpoint, won't this require initialization on the driver?
+
 No. If a Predictor is created from an AIR Checkpoint, we delay the initialization to a `setup` call that happens only in the 
 actor.
 

--- a/reps/2023-03-10-batch-inference.md
+++ b/reps/2023-03-10-batch-inference.md
@@ -298,7 +298,7 @@ class BatchMappable(Callable[[T], U]):
 
 `map_batches` will support instances of `BatchMappable` as a supported UDF
 
-2. Add a private `to_checkpoint` serializer for `Predictor`, analagous to the current `from_checkpoint` deserializer. Also, move the 
+2. Add a private `to_checkpoint` serializer for `Predictor`, analagous to the current `from_checkpoint` deserializer. 
 
 ```python
 class Predictor:

--- a/reps/2023-03-10-batch-inference.md
+++ b/reps/2023-03-10-batch-inference.md
@@ -88,9 +88,7 @@ def map_predictor(predictor: Union[Predictor, Callable[[], Predictor]],
         ``predict()`` method.
   """
 ```
-
-3. Deprecate `Chain` Preprocessor, as chains can be represented via multiple `map_preprocessor` calls.
-4. Deprecate `BatchMapper`, as the same functionality can be achieved via `map_batches`.
+3. Deprecate `BatchMapper`, as the same functionality can be achieved via `map_batches`.
       
 ## Example: Multi-stage Inference Pipeline from pre-trained model
 

--- a/reps/2023-03-10-batch-inference.md
+++ b/reps/2023-03-10-batch-inference.md
@@ -124,7 +124,7 @@ predictor = TorchPredictor(model)
 predictions = ds.read_parquet("s3://data")
     .map_batches(lambda x: x+1)
     .map_preprocessor(TorchVisionPreprocessor(torchvision.transforms.Crop(224, 224)))
-    .map_predict(predictor)
+    .map_predictor(predictor)
 ```
 
 ## Compatibility, Deprecation, and Migration Plan

--- a/reps/2023-03-10-batch-inference.md
+++ b/reps/2023-03-10-batch-inference.md
@@ -86,6 +86,7 @@ def map_predictor(predictor: Union[Predictor, Callable[[], Predictor]],
     ray_remote_args: Additional resource requirements to request from ray.
     predict_kwargs: Keyword arguments passed to the predictor's
         ``predict()`` method.
+  """
 ```
 
 3. Deprecate `Chain` Preprocessor, as chains can be represented via multiple `map_preprocessor` calls.

--- a/reps/2023-03-10-batch-inference.md
+++ b/reps/2023-03-10-batch-inference.md
@@ -385,7 +385,7 @@ def map_batches(
 ## FAQ
 1. If I pass in a `Predictor` directly, won't initiliazation happen for every batch?
 
-No. `Predictors` will require the use of a Callable Class, and so that we wrap the Predictor in a Callable class internally, like in the example above.
+No. `Predictors` will require the use of a Callable Class, and so we wrap the Predictor in a Callable class internally, like in the example above.
 
 2. If I have an AIR Checkpoint, won't this require initialization on the driver?
 

--- a/reps/2023-03-10-batch-inference.md
+++ b/reps/2023-03-10-batch-inference.md
@@ -269,7 +269,7 @@ class BatchMappable(Callable[[T], U]):
         """
         pass
        
-    def validate_batch_format(self, batch_format: Optional[str]) -> Optional[str]:
+    def get_batch_format(self, batch_format: Optional[str]) -> Optional[str]:
         """Validate that the provided `batch_format` is compatible with this `BatchMappable`.
 
         Raises an error if the provided `batch_format` is not supported with this `BatchMappable` 

--- a/reps/2023-03-10-batch-inference.md
+++ b/reps/2023-03-10-batch-inference.md
@@ -51,7 +51,7 @@ def map_preprocessor(preprocessor: Preprocessor, batch_size: Optional[int], pref
 2. Introduce a `map_predictor` API directly to Ray Datasets.
 
 ```python
-def map_predictor(predictor: Union[Predictor, Callable[[], Predictor]], 
+def map_predictor(predictor: Callable[[], Predictor]], 
                   batch_size: Optional[int], 
                   feature_columns: Optional[List[str]] = None, 
                   keep_columns: Optional[List[str]] = None, 
@@ -64,8 +64,7 @@ def map_predictor(predictor: Union[Predictor, Callable[[], Predictor]],
   """Predict on batches of data.
 
   Args:
-    predictor: An instance of a Predictor to use for prediction. For Predictors that are not serializable, or are loading large models
-      or that are created from AIR Checkpoints, a function that creates a Predictor can be passed in instead. 
+    predictor: A function that returns a Predictor to use for inference.
     batch_size: Batch size to use for prediction.
     feature_columns: List of columns in the preprocessed dataset to use for
       prediction. Columns not specified will be dropped
@@ -110,11 +109,7 @@ predictions = batch_predictor.predict(ds)
 
 ### After
 ```python
-model = pretrained_resnet()
-predictor = TorchPredictor(model)
-
-# Alternatively, delayed model creation
-# predictor = lambda: TorchPredictor(pretrained_resnet())
+predictor = lambda: TorchPredictor(pretrained_resnet())
 
 # Alternatively, create from AIR Checkpoint.
 # predictor = lambda: TorchPredictor.from_checkpoint(air_checkpoint)

--- a/reps/2023-03-10-batch-inference.md
+++ b/reps/2023-03-10-batch-inference.md
@@ -1,7 +1,7 @@
 # Revamping APIs for Offline Batch Inference
 
 ## Summary
-Reduce the friction for batch inference of pre-trained by updating the APIs to do the following:
+Reduce the friction for batch inference of pre-trained models by updating the APIs to do the following:
 1. Remove AIR Checkpoints from the critical path for batch prediction.
 2. Simpler interface for chaining multiple preprocessing and prediction stages.
 


### PR DESCRIPTION
Reduce the friction for batch inference of pre-trained by updating the APIs to do the following:
1. Remove AIR Checkpoints from the critical path for batch prediction.
2. Simpler interface for chaining multiple preprocessing and prediction stages.